### PR TITLE
CADP-8729: Fixed a memory leak in pkcs11_sample_encrypt_decrypt

### DIFF
--- a/pkcs11/C/pkcs11_sample_encrypt_decrypt.c
+++ b/pkcs11/C/pkcs11_sample_encrypt_decrypt.c
@@ -375,6 +375,9 @@ static CK_RV encryptDecryptBuf(CK_SESSION_HANDLE hSess, CK_MECHANISM *pMechEnc, 
             return CKR_GENERAL_ERROR;
         }
     }
+	if (decryptedText) {
+		free(decryptedText);
+	}
     else return CKR_OK;
 }
 


### PR DESCRIPTION
CADP-8729: Fixed a memory leak in pkcs11_sample_encrypt_decrypt

Tests:
Unit tested with pkcs11_sample_encrypt_decrypt
